### PR TITLE
Refactor of helperfunctionsjs

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import './App.css'
-import helpers from '../modules/helperFunctions'
+import getExtraStats from '../modules/helperFunctions'
 import grips from '../modules/grip'
 import links from '../modules/link'
 import strikes from '../modules/strike'
@@ -44,6 +44,7 @@ function App () {
   function createZaw () {
     const zawType = zawParts.grip.type ? zawParts.strike.type2 : zawParts.strike.type1
     const zawDamage = zawParts.strike.dmg + zawParts.grip.dmgMod + zawParts.link.dmgMod
+    const zawExtraStats = getExtraStats(zawType)
     setZawStats({
       speed: zawParts.grip.speed + zawParts.strike.spdMod + zawParts.link.spdMod,
       type: zawType,
@@ -62,17 +63,17 @@ function App () {
       heavySlamAtk: 'WIP',
       heavySlamRadialDmg: 'WIP',
       heavySlamRadius: 'WIP',
-      windUp: helpers.getWindup(zawType),
+      windUp: zawExtraStats.windUp,
       // extras
       stancePolarity: zawParts.grip.type ? zawParts.strike.polarity2 : zawParts.strike.polarity1,
       range: zawParts.grip.type ? zawParts.strike.range2 : zawParts.strike.range1,
-      slamAtk: (helpers.getSlamMultiplier(zawType)) * zawDamage,
+      slamAtk: zawExtraStats.slamMultiplier * zawDamage,
       slamRadialDmg: zawDamage,
-      slamRadius: `${helpers.getSlamRadius(zawType)}m`,
+      slamRadius: `${zawExtraStats.slamRadius}m`,
       slideAtk: 'WIP',
-      blockAngle: helpers.getBlockAngle(zawType),
+      blockAngle: zawExtraStats.blockAngle,
       comboDuration: 5,
-      followThrough: helpers.getFollowThrough(zawType)
+      followThrough: zawExtraStats.followThrough
     })
   }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -59,10 +59,10 @@ function App () {
       puncture: Math.round((zawDamage * (zawParts.strike.puncture / 100)) * 10) / 10,
       viral: Math.round((zawDamage * (zawParts.strike.viral / 100)) * 10) / 10,
       // heavy attack
-      heavyDmg: 'WIP',
-      heavySlamAtk: 'WIP',
-      heavySlamRadialDmg: 'WIP',
-      heavySlamRadius: 'WIP',
+      heavyDmg: zawExtraStats.heavyMultiplier * zawDamage,
+      heavySlamAtk: zawExtraStats.heavySlamMultiplier * zawDamage,
+      heavySlamRadialDmg: zawExtraStats.heavySlamMultiplier * zawDamage,
+      heavySlamRadius: 'WIP', // No info on wiki, have to do my own research
       windUp: zawExtraStats.windUp,
       // extras
       stancePolarity: zawParts.grip.type ? zawParts.strike.polarity2 : zawParts.strike.polarity1,
@@ -70,7 +70,7 @@ function App () {
       slamAtk: zawExtraStats.slamMultiplier * zawDamage,
       slamRadialDmg: zawDamage,
       slamRadius: `${zawExtraStats.slamRadius}m`,
-      slideAtk: 'WIP',
+      slideAtk: 'WIP', // No info on wiki, have to do my own research
       blockAngle: zawExtraStats.blockAngle,
       comboDuration: 5,
       followThrough: zawExtraStats.followThrough
@@ -115,6 +115,7 @@ function App () {
           <h3>PRIMARY:</h3>
           <p>Type: {zawStats.type}</p>
           <p>Speed: {zawStats.speed}</p>
+          <p>Range: {zawStats.range}</p>
           <h3>DAMAGE:</h3>
           <p>Dmg: {zawStats.dmgTotal} {`(Mainly ${zawStats.dmgType}, ${zawParts.strike[zawStats.dmgType]}%)`}</p>
           <p>Slash: {zawStats.slash}</p>
@@ -124,20 +125,6 @@ function App () {
           <p>Crit chance: {`${zawStats.crtChance}%`}</p>
           <p>Crit damage: {`${zawStats.crtMultiplier} X`}</p>
           <p>Status: {`${zawStats.statusChance}%`}</p>
-
-          {/*
-            //heavy attack
-            heavyDmg: 'WIP',
-            heavySlamAtk: 'WIP',
-            heavySlamRadialDmg: 'WIP',
-            heavySlamRadius: 'WIP',
-            //extras
-            slamAtk: 'WIP',
-            slamRadialDmg: 'WIP',
-            slamRadius: 'WIP',
-            slideAtk: 'WIP',
-          */}
-
         </div>
       </div>
 

--- a/src/modules/helperFunctions.js
+++ b/src/modules/helperFunctions.js
@@ -1,174 +1,3 @@
-// WIP: this has to be compared to real-game stats
-const getFollowThrough = (type) => {
-  switch (type) {
-    case 'Hammer' :
-    case 'Heavy Scythe': return 0.4
-    case 'Blade and Whip' :
-    case 'Staff' :
-    case 'Dual Swords' :
-    case 'Gunblade' :
-    case 'Nunchaku' :
-    case 'Whip': return 0.5
-    case 'Heavy Blade' :
-    case 'Polearm':
-    case 'Scythe' :
-    case 'Sword' :
-    case 'Sword and Shield' :
-    case 'Tonfa': return 0.6
-    case 'Glaive' :
-    case 'Machete' :
-    case 'Nikana' :
-    case 'Rapier' :
-    case 'Two-Handed Nikana' :
-    case 'Warfan': return 0.7
-    case 'Claws' :
-    case 'Dual Daggers': return 0.8
-    case 'Dagger' :
-    case 'Fist' :
-    case 'Sparring': return 0.9
-    case 'Assault Saw': return 1
-  }
-}
-
-// WIP: this has to be compared to real-game stats
-const getBlockAngle = (type) => {
-  switch (type) {
-    case 'Dagger':
-    case 'Gunblade':
-    case 'Whip': return 45
-    case 'Dual Daggers':
-    case 'Fist' :
-    case 'Hammer':
-    case 'Sparring': return 50
-    case 'Claws':
-    case 'Glaive':
-    case 'Heavy Blade':
-    case 'Machete':
-    case 'Nikana':
-    case 'Nunchaku':
-    case 'Polearm':
-    case 'Sword':
-    case 'Two-Handed Nikana':
-    case 'Warfan': return 55
-    case 'Blade and Whip':
-    case 'Dual Swords':
-    case 'Rapier':
-    case 'Scythe':
-    case 'Staff':
-    case 'Tonfa': return 60
-    case 'Heavy Scythe': return 65
-    case 'Sword and Shield': return 70
-    case 'Assault Saw': return 90
-  }
-}
-
-// WIP: this has to be compared to real-game stats
-const getWindup = (type) => {
-  switch (type) {
-    case 'Blade and Whip':
-    case 'Dagger':
-    case 'Gunblade':
-    case 'Whip': return 0.4
-    case 'Dual Daggers':
-    case 'Nikana':
-    case 'Nunchaku':
-    case 'Rapier':
-    case 'Sparring':
-    case 'Staff':
-    case 'Warfan': return 0.5
-    case 'Claws':
-    case 'Fist' :
-    case 'Glaive':
-    case 'Sword': return 0.6
-    case 'Dual Swords':
-    case 'Machete':
-    case 'Sword and Shield':
-    case 'Tonfa':
-    case 'Two-Handed Nikana': return 0.7
-    case 'Polearm': return 0.9
-    case 'Assault Saw':
-    case 'Scythe':
-    case 'Heavy Scythe': return 1.0
-    case 'Heavy Blade': return 1.1
-    case 'Hammer': return 1.2
-  }
-}
-
-// WIP: this has to be compared to real-game stats
-const getSlamMultiplier = (type) => {
-  switch (type) {
-    case 'Dagger':
-    case 'Dual Daggers':
-    case 'Nunchaku':
-    case 'Dual Swords':
-    case 'Tonfa': return 2
-    default: return 3
-  }
-}
-
-// WIP: this has to be compared to real-game stats
-const getSlamRadius = (type) => {
-  switch (type) {
-    case 'Dagger':
-    case 'Glaive':
-    case 'Gunblade':
-    case 'Warfan':
-    case 'Whip': return 5
-    case 'Dual Daggers':
-    case 'Nunchaku':
-    case 'Claws':
-    case 'Nikana':
-    case 'Rapier':
-    case 'Staff': return 6
-    case 'Assault Saw':
-    case 'Blade and Whip':
-    case 'Polearm':
-    case 'Sparring':
-    case 'Sword':
-    case 'Sword and Shield':
-    case 'Two-Handed Nikana': return 7
-    case 'Dual Swords':
-    case 'Tonfa':
-    case 'Fist' :
-    case 'Heavy Blade':
-    case 'Heavy Scythe':
-    case 'Machete':
-    case 'Scythe': return 8
-    case 'Hammer': return 9
-  }
-}
-
-const getHeavyMultiplier = (type) => {
-  switch (type) {
-    case 'Glaive': return 2
-    case 'Blade and Whip':
-    case 'Gunblade': return 4
-    case 'Rapier':
-    case 'Whip': return 4.5
-    case 'Claws':
-    case 'Dagger':
-    case 'Dual Daggers':
-    case 'Dual Swords':
-    case 'Fist':
-    case 'Nikana':
-    case 'Nunchaku':
-    case 'Sparring':
-    case 'Staff':
-    case 'Sword':
-    case 'Sword and Shield':
-    case 'Tonfa':
-    case 'Warfan': return 5
-    case 'Assault Saw':
-    case 'Hammer':
-    case 'Heavy Blade':
-    case 'Heavy Scythe':
-    case 'Machete':
-    case 'Polearm':
-    case 'Scythe':
-    case 'Two-Handed Nikana': return 6
-  }
-}
-
 // WIP, Missing: slam radius, heavy multiplier, heavy slam, heavy slam radius
 const getExtraStats = (type) => {
   switch (type) {
@@ -176,188 +5,237 @@ const getExtraStats = (type) => {
       return {
         followThrough: 1,
         blockAngle: 90,
-        windup: 1.0,
-        slamMultiplier: 3
-
+        windUp: 1.0,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 6
       }
     case 'Blade and Whip':
       return {
         followThrough: 0.5,
         blockAngle: 60,
-        windup: 0.4,
-        slamMultiplier: 3
+        windUp: 0.4,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 4
       }
     case 'Claws':
       return {
         followThrough: 0.8,
         blockAngle: 55,
-        windup: 0.6,
-        slamMultiplier: 3
+        windUp: 0.6,
+        slamMultiplier: 3,
+        slamRadius: 6,
+        heavyMultiplier: 5
       }
     case 'Dagger':
       return {
         followThrough: 0.9,
         blockAngle: 45,
-        windup: 0.4,
-        slamMultiplier: 2
+        windUp: 0.4,
+        slamMultiplier: 2,
+        slamRadius: 5,
+        heavyMultiplier: 5
       }
     case 'Dual Daggers':
       return {
         followThrough: 0.8,
         blockAngle: 50,
-        windup: 0.5,
-        slamMultiplier: 2
+        windUp: 0.5,
+        slamMultiplier: 2,
+        slamRadius: 6,
+        heavyMultiplier: 5
       }
     case 'Dual Swords':
       return {
         followThrough: 0.5,
         blockAngle: 60,
-        windup: 0.7,
-        slamMultiplier: 2
+        windUp: 0.7,
+        slamMultiplier: 2,
+        slamRadius: 8,
+        heavyMultiplier: 5
       }
     case 'Fist':
       return {
         followThrough: 0.9,
         blockAngle: 50,
-        windup: 0.6,
-        slamMultiplier: 3
+        windUp: 0.6,
+        slamMultiplier: 3,
+        slamRadius: 8,
+        heavyMultiplier: 5
       }
     case 'Glaive':
       return {
         followThrough: 0.7,
         blockAngle: 55,
-        windup: 0.6,
-        slamMultiplier: 3
+        windUp: 0.6,
+        slamMultiplier: 3,
+        slamRadius: 5,
+        heavyMultiplier: 2
       }
     case 'Gunblade':
       return {
         followThrough: 0.5,
         blockAngle: 45,
-        windup: 0.4,
-        slamMultiplier: 3
+        windUp: 0.4,
+        slamMultiplier: 3,
+        slamRadius: 5,
+        heavyMultiplier: 4
       }
     case 'Hammer':
       return {
         followThrough: 0.4,
         blockAngle: 50,
-        windup: 1.2,
-        slamMultiplier: 3
+        windUp: 1.2,
+        slamMultiplier: 3,
+        slamRadius: 9,
+        heavyMultiplier: 6
       }
     case 'Heavy Blade':
       return {
         followThrough: 0.6,
         blockAngle: 55,
-        windup: 1.1,
-        slamMultiplier: 3
+        windUp: 1.1,
+        slamMultiplier: 3,
+        slamRadius: 8,
+        heavyMultiplier: 6
       }
     case 'Heavy Scythe':
       return {
         followThrough: 0.4,
         blockAngle: 65,
-        windup: 1.0,
-        slamMultiplier: 3
+        windUp: 1.0,
+        slamMultiplier: 3,
+        slamRadius: 8,
+        heavyMultiplier: 6
       }
     case 'Machete':
       return {
         followThrough: 0.7,
         blockAngle: 55,
-        windup: 0.7,
-        slamMultiplier: 3
+        windUp: 0.7,
+        slamMultiplier: 3,
+        slamRadius: 8,
+        heavyMultiplier: 6
       }
     case 'Nikana':
       return {
         followThrough: 0.7,
         blockAngle: 55,
-        windup: 0.5,
-        slamMultiplier: 3
+        windUp: 0.5,
+        slamMultiplier: 3,
+        slamRadius: 6,
+        heavyMultiplier: 5
       }
     case 'Nunchaku':
       return {
         followThrough: 0.5,
         blockAngle: 55,
-        windup: 0.5,
-        slamMultiplier: 2
+        windUp: 0.5,
+        slamMultiplier: 2,
+        slamRadius: 6,
+        heavyMultiplier: 5
       }
     case 'Polearm':
       return {
         followThrough: 0.6,
         blockAngle: 55,
-        windup: 0.9,
-        slamMultiplier: 3
+        windUp: 0.9,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 6
       }
     case 'Rapier':
       return {
         followThrough: 0.7,
         blockAngle: 60,
-        windup: 0.5,
-        slamMultiplier: 3
+        windUp: 0.5,
+        slamMultiplier: 3,
+        slamRadius: 6,
+        heavyMultiplier: 4.5
       }
     case 'Scythe':
       return {
         followThrough: 0.6,
         blockAngle: 60,
-        windup: 1.0,
-        slamMultiplier: 3
+        windUp: 1.0,
+        slamMultiplier: 3,
+        slamRadius: 8,
+        heavyMultiplier: 6
       }
     case 'Sparring':
       return {
         followThrough: 0.9,
         blockAngle: 50,
-        windup: 0.5,
-        slamMultiplier: 3
+        windUp: 0.5,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 5
       }
     case 'Staff':
       return {
         followThrough: 0.5,
         blockAngle: 60,
-        windup: 0.5,
-        slamMultiplier: 3
+        windUp: 0.5,
+        slamMultiplier: 3,
+        slamRadius: 6,
+        heavyMultiplier: 5
       }
     case 'Sword':
       return {
         followThrough: 0.6,
         blockAngle: 55,
-        windup: 0.6,
-        slamMultiplier: 3
+        windUp: 0.6,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 5
       }
     case 'Sword and Shield':
       return {
         followThrough: 0.6,
         blockAngle: 70,
-        windup: 0.7,
-        slamMultiplier: 3
+        windUp: 0.7,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 5
       }
     case 'Tonfa':
       return {
         followThrough: 0.6,
         blockAngle: 60,
-        windup: 0.7,
-        slamMultiplier: 2
+        windUp: 0.7,
+        slamMultiplier: 2,
+        slamRadius: 8,
+        heavyMultiplier: 5
       }
     case 'Two-Handed Nikana':
       return {
         followThrough: 0.7,
         blockAngle: 55,
-        windup: 0.7,
-        slamMultiplier: 3
+        windUp: 0.7,
+        slamMultiplier: 3,
+        slamRadius: 7,
+        heavyMultiplier: 6
       }
     case 'Warfan':
       return {
         followThrough: 0.7,
         blockAngle: 55,
-        windup: 0.5,
-        slamMultiplier: 3
+        windUp: 0.5,
+        slamMultiplier: 3,
+        slamRadius: 5,
+        heavyMultiplier: 5
       }
     case 'Whip':
       return {
         followThrough: 0.5,
         blockAngle: 45,
-        windup: 0.4,
-        slamMultiplier: 3
+        windUp: 0.4,
+        slamMultiplier: 3,
+        slamRadius: 5,
+        heavyMultiplier: 4.5
       }
   }
 }
 
-const helpers = { getFollowThrough, getBlockAngle, getWindup, getSlamMultiplier, getSlamRadius, getHeavyMultiplier }
-
-export default helpers
+export default getExtraStats

--- a/src/modules/helperFunctions.js
+++ b/src/modules/helperFunctions.js
@@ -169,6 +169,195 @@ const getHeavyMultiplier = (type) => {
   }
 }
 
+// WIP, Missing: slam radius, heavy multiplier, heavy slam, heavy slam radius
+const getExtraStats = (type) => {
+  switch (type) {
+    case 'Assault Saw':
+      return {
+        followThrough: 1,
+        blockAngle: 90,
+        windup: 1.0,
+        slamMultiplier: 3
+
+      }
+    case 'Blade and Whip':
+      return {
+        followThrough: 0.5,
+        blockAngle: 60,
+        windup: 0.4,
+        slamMultiplier: 3
+      }
+    case 'Claws':
+      return {
+        followThrough: 0.8,
+        blockAngle: 55,
+        windup: 0.6,
+        slamMultiplier: 3
+      }
+    case 'Dagger':
+      return {
+        followThrough: 0.9,
+        blockAngle: 45,
+        windup: 0.4,
+        slamMultiplier: 2
+      }
+    case 'Dual Daggers':
+      return {
+        followThrough: 0.8,
+        blockAngle: 50,
+        windup: 0.5,
+        slamMultiplier: 2
+      }
+    case 'Dual Swords':
+      return {
+        followThrough: 0.5,
+        blockAngle: 60,
+        windup: 0.7,
+        slamMultiplier: 2
+      }
+    case 'Fist':
+      return {
+        followThrough: 0.9,
+        blockAngle: 50,
+        windup: 0.6,
+        slamMultiplier: 3
+      }
+    case 'Glaive':
+      return {
+        followThrough: 0.7,
+        blockAngle: 55,
+        windup: 0.6,
+        slamMultiplier: 3
+      }
+    case 'Gunblade':
+      return {
+        followThrough: 0.5,
+        blockAngle: 45,
+        windup: 0.4,
+        slamMultiplier: 3
+      }
+    case 'Hammer':
+      return {
+        followThrough: 0.4,
+        blockAngle: 50,
+        windup: 1.2,
+        slamMultiplier: 3
+      }
+    case 'Heavy Blade':
+      return {
+        followThrough: 0.6,
+        blockAngle: 55,
+        windup: 1.1,
+        slamMultiplier: 3
+      }
+    case 'Heavy Scythe':
+      return {
+        followThrough: 0.4,
+        blockAngle: 65,
+        windup: 1.0,
+        slamMultiplier: 3
+      }
+    case 'Machete':
+      return {
+        followThrough: 0.7,
+        blockAngle: 55,
+        windup: 0.7,
+        slamMultiplier: 3
+      }
+    case 'Nikana':
+      return {
+        followThrough: 0.7,
+        blockAngle: 55,
+        windup: 0.5,
+        slamMultiplier: 3
+      }
+    case 'Nunchaku':
+      return {
+        followThrough: 0.5,
+        blockAngle: 55,
+        windup: 0.5,
+        slamMultiplier: 2
+      }
+    case 'Polearm':
+      return {
+        followThrough: 0.6,
+        blockAngle: 55,
+        windup: 0.9,
+        slamMultiplier: 3
+      }
+    case 'Rapier':
+      return {
+        followThrough: 0.7,
+        blockAngle: 60,
+        windup: 0.5,
+        slamMultiplier: 3
+      }
+    case 'Scythe':
+      return {
+        followThrough: 0.6,
+        blockAngle: 60,
+        windup: 1.0,
+        slamMultiplier: 3
+      }
+    case 'Sparring':
+      return {
+        followThrough: 0.9,
+        blockAngle: 50,
+        windup: 0.5,
+        slamMultiplier: 3
+      }
+    case 'Staff':
+      return {
+        followThrough: 0.5,
+        blockAngle: 60,
+        windup: 0.5,
+        slamMultiplier: 3
+      }
+    case 'Sword':
+      return {
+        followThrough: 0.6,
+        blockAngle: 55,
+        windup: 0.6,
+        slamMultiplier: 3
+      }
+    case 'Sword and Shield':
+      return {
+        followThrough: 0.6,
+        blockAngle: 70,
+        windup: 0.7,
+        slamMultiplier: 3
+      }
+    case 'Tonfa':
+      return {
+        followThrough: 0.6,
+        blockAngle: 60,
+        windup: 0.7,
+        slamMultiplier: 2
+      }
+    case 'Two-Handed Nikana':
+      return {
+        followThrough: 0.7,
+        blockAngle: 55,
+        windup: 0.7,
+        slamMultiplier: 3
+      }
+    case 'Warfan':
+      return {
+        followThrough: 0.7,
+        blockAngle: 55,
+        windup: 0.5,
+        slamMultiplier: 3
+      }
+    case 'Whip':
+      return {
+        followThrough: 0.5,
+        blockAngle: 45,
+        windup: 0.4,
+        slamMultiplier: 3
+      }
+  }
+}
+
 const helpers = { getFollowThrough, getBlockAngle, getWindup, getSlamMultiplier, getSlamRadius, getHeavyMultiplier }
 
 export default helpers


### PR DESCRIPTION
## Added _`getExtraStats`_

<details><summary>Merged all helper functions into a new function, getExtraStats</summary>
<ul>
<li> getFollowThrough </li>
<li> getBlockAngle</li>
<li> getWindup</li>
<li> getSlamMultiplier</li>
<li> getSlamRadius</li>
<li> getHeavyMultiplier</li>
</ul>
</details> 

This function will return an object containing all the values from the merged functions, which allows for a single call on [App.js](https://github.com/Kakalanp/zaw-builder/blob/cd1674e0f24ca4f38df1517dbbba500d796fe7d2/src/components/App.js), as described in:

- #1

> [!NOTE]
> There's still a couple values I wasn't able to get from the [Zaw](https://warframe.fandom.com/wiki/Zaw) or [Melee](https://warframe.fandom.com/wiki/Melee) pages of the [wiki](https://warframe.fandom.com/wiki/WARFRAME_Wiki), research has to be done from my end to retrieve the correct values for `slideAtk` and `heavySlamRadius`

-----

The following is the progress made compiling data for the above-mentioned stats (`slideAtk` and `heavySlamRadius`):

| Weapon type | `slideAtk` | `heavySlamRadius` | Weapon used|
|--------|--------|--------|--------|
| Dual daggers | 2X | 7m | Okina |
| Hammer | 2X | 10m | Arca Titron | 
| Nikana | 2X | 7m | Skiajati, Zaw | 
| Sword | 1X | 8m | Broken War |

**Further exploration is required.**

-----

>Preview of getExtraStats:
>
>https://github.com/Kakalanp/zaw-builder/blob/2e15c55bb473ae696e858a53e917aab69630308a/src/modules/helperFunctions.js#L2-L238
